### PR TITLE
Allow database passwords that contain "$"

### DIFF
--- a/templates/db.inc.php.j2
+++ b/templates/db.inc.php.j2
@@ -35,7 +35,7 @@ if (!isset($config)) $config = new stdClass();
  $config->db_user = "{{ opensips_cp_db_user }}";
  
  //database connection password
- $config->db_pass = "{{ opensips_cp_db_pass }}";
+ $config->db_pass = '{{ opensips_cp_db_pass }}';
  
  //database name
  $config->db_name = "{{ opensips_cp_db }}";


### PR DESCRIPTION
PHP does string interpolation in strings in double quotes, which means if passwords contain a "$", they get replaced.