### PR TITLE
Fix issues around the cron stat collection

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,9 +56,9 @@
 - name: Configure cron
   template:
     src: cron.d.j2
-    dest: "/etc/cron.d"
+    dest: "/etc/cron.d/opensips_stats_cron"
     mode: 0644
-    owner: "{{ opensips_cp_user }}"
+    owner: "root"
   when: opensips_cp_stats
 
 - name: Configure database


### PR DESCRIPTION
* avoid naming the file "cron.d.j2" (seems to be ignored)
* always set the owner to "root" (this is standard)

Fixes #5